### PR TITLE
Implementation

### DIFF
--- a/flash.h
+++ b/flash.h
@@ -1,0 +1,30 @@
+#ifndef FLASH_H
+#define FLASH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void flash_lock(void);
+void flash_unlock(void);
+
+/* Write data of size len at addr.
+ * Note: flash must be unlocket for this operation. */
+void flash_write(void *addr, const void *data, size_t len);
+
+/** Erase sector given by its base address.
+ *
+ * @note flash must be unlocked for this operation.
+ */
+void flash_sector_erase(void *addr);
+
+uint8_t flash_addr_to_sector(void *p);
+void flash_sector_erase_number(uint8_t sector);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLASH_H */

--- a/flash.h
+++ b/flash.h
@@ -11,7 +11,7 @@ void flash_lock(void);
 void flash_unlock(void);
 
 /* Write data of size len at addr.
- * Note: flash must be unlocket for this operation. */
+ * Note: flash must be unlocked for this operation. */
 void flash_write(void *addr, const void *data, size_t len);
 
 /** Erase sector given by its base address.
@@ -19,9 +19,6 @@ void flash_write(void *addr, const void *data, size_t len);
  * @note flash must be unlocked for this operation.
  */
 void flash_sector_erase(void *addr);
-
-uint8_t flash_addr_to_sector(void *p);
-void flash_sector_erase_number(uint8_t sector);
 
 #ifdef __cplusplus
 }

--- a/flash_f4.c
+++ b/flash_f4.c
@@ -1,0 +1,123 @@
+#include <stdint.h>
+#include <stddef.h>
+#include "flash.h"
+
+/* Flash registers. Copied here to avoid dependencies on either libopencm3 or
+ * ChibiOS. */
+#define MMIO32(addr) (*(volatile uint32_t *)(addr))
+#define FLASH_MEM_INTERFACE_BASE 0x40023C00
+#define FLASH_ACR                MMIO32(FLASH_MEM_INTERFACE_BASE + 0x00)
+#define FLASH_KEYR               MMIO32(FLASH_MEM_INTERFACE_BASE + 0x04)
+#define FLASH_OPTKEYR            MMIO32(FLASH_MEM_INTERFACE_BASE + 0x08)
+#define FLASH_SR                 MMIO32(FLASH_MEM_INTERFACE_BASE + 0x0C)
+#define FLASH_CR                 MMIO32(FLASH_MEM_INTERFACE_BASE + 0x10)
+
+#define FLASH_KEY1               0x45670123
+#define FLASH_KEY2               0xCDEF89AB
+#define FLASH_CR_SNB_POS         3
+#define FLASH_CR_LOCK            (1 << 31)
+#define FLASH_CR_PSIZE           ((uint32_t)0x03 << 8)
+#define FLASH_CR_PG              (1 << 0)
+#define FLASH_CR_SNB             ((uint32_t)0x000000F8)
+#define FLASH_CR_SER             ((uint32_t)0x00000002)
+#define FLASH_CR_STRT            ((uint32_t)0x00010000)
+
+#define FLASH_SR_BSY             (1 << 16)
+
+uint8_t flash_addr_to_sector(void *p)
+{
+    uint32_t addr = (uint32_t)p;
+    uint8_t sector;
+    uint32_t offset = addr & 0xFFFFFF;
+    if (offset < 0x10000) {
+        sector = offset / 0x4000; // 16K sectors, 0x08000000 to 0x0800FFFF
+    } else if (offset < 0x20000) {
+        sector = 3 + offset / 0x10000; // 64K sector, 0x08010000 to 0x0801FFFF
+    } else {
+        sector = 4 + offset / 0x20000; // 128K sectors, 0x08010000 to 0x080FFFFF
+    }
+    if (addr >= 0x08100000) {
+        // Bank 2, same layout, starting at 0x08100000
+        sector += 12;
+    }
+    return sector;
+}
+
+void flash_lock(void)
+{
+    FLASH_CR |= FLASH_CR_LOCK;
+}
+
+void flash_unlock(void)
+{
+    // ensure cleared state
+    FLASH_CR |= FLASH_CR_LOCK;
+
+    // unlock flash access
+    FLASH_KEYR = FLASH_KEY1;
+    FLASH_KEYR = FLASH_KEY2;
+}
+
+static void flash_set_parallelism_8x(void)
+{
+    // parallelism 8x, one byte write/erase
+    FLASH_CR &= ~FLASH_CR_PSIZE;
+}
+
+static void flash_wait_while_busy(void)
+{
+    while ((FLASH_SR & FLASH_SR_BSY) != 0) {
+    }
+}
+
+static void flash_write_byte(uint8_t *flash, uint8_t byte)
+{
+    // activate flash programming
+    FLASH_CR |= FLASH_CR_PG;
+    // perform byte write
+    *flash = byte;
+
+    flash_wait_while_busy();
+}
+
+void flash_write(void *addr, const void *data, size_t len)
+{
+    flash_wait_while_busy();
+
+    /* Note:
+     * This is a possible point of optimization of energy/time consumption
+     * Different parallelism size of erase and write operations can be cosen
+     * depending on the supply voltage. */
+    flash_set_parallelism_8x();
+
+    uint8_t *r = (uint8_t *)data;
+    uint8_t *w = (uint8_t *)addr;
+
+    while (len-- > 0) {
+        flash_write_byte(w++, *r++);
+    }
+
+    // clear flags
+    FLASH_CR &= ~FLASH_CR_PG;
+}
+
+void flash_sector_erase(void *addr)
+{
+    uint32_t sector = flash_addr_to_sector(addr);
+
+    flash_sector_erase_number(sector);
+}
+
+void flash_sector_erase_number(uint8_t sector)
+{
+    flash_set_parallelism_8x();
+
+    flash_wait_while_busy();
+
+    FLASH_CR &= ~FLASH_CR_SNB;
+    FLASH_CR |= (sector << FLASH_CR_SNB_POS) & FLASH_CR_SNB;
+    FLASH_CR |= FLASH_CR_SER;
+    FLASH_CR |= FLASH_CR_STRT;
+
+    flash_wait_while_busy();
+}

--- a/package.yml
+++ b/package.yml
@@ -6,6 +6,9 @@ depends:
 source:
   - parameter_flash_storage.c
 
+target.stm32f4:
+  - flash_f4.c
+
 tests:
   - tests/flash_mock.cpp
   - tests/parameter_flash_storage.cpp

--- a/package.yml
+++ b/package.yml
@@ -1,0 +1,11 @@
+depends:
+  - parameter
+  - crc
+  - test-runner
+
+source:
+  - parameter_flash_storage.c
+
+tests:
+  - tests/flash_mock.cpp
+  - tests/parameter_flash_storage.cpp

--- a/parameter_flash_storage.c
+++ b/parameter_flash_storage.c
@@ -2,10 +2,10 @@
 #include "parameter_flash_storage.h"
 #include "parameter_flash_storage_private.h"
 #include "flash.h"
-#include "parameter/parameter_msgpack.h"
-#include "cmp/cmp.h"
-#include "cmp_mem_access/cmp_mem_access.h"
-#include "crc/crc32.h"
+#include <parameter/parameter_msgpack.h>
+#include <cmp/cmp.h>
+#include <cmp_mem_access/cmp_mem_access.h>
+#include <crc/crc32.h>
 
 /* We cannot use a CRC start value of 0 because CRC(0, 0xffffffff) = 0xffffffff
  * which makes empty flash pages valid. */
@@ -44,7 +44,7 @@ void parameter_flash_storage_save(void *dst, size_t dst_len, parameter_namespace
 {
     cmp_ctx_t cmp;
     cmp_mem_access_t mem;
-    uint32_t len;
+    size_t len;
     bool success = true;
 
     void *orig_dst = dst;

--- a/parameter_flash_storage.c
+++ b/parameter_flash_storage.c
@@ -1,0 +1,203 @@
+#include <string.h>
+#include "parameter_flash_storage.h"
+#include "parameter_flash_storage_private.h"
+#include "flash.h"
+#include "parameter/parameter_msgpack.h"
+#include "cmp/cmp.h"
+#include "cmp_mem_access/cmp_mem_access.h"
+#include "crc/crc32.h"
+
+/* We cannot use a CRC start value of 0 because CRC(0, 0xffffffff) = 0xffffffff
+ * which makes empty flash pages valid. */
+#define CRC_INITIAL_VALUE 0xdeadbeef
+
+
+static size_t cmp_flash_writer(struct cmp_ctx_s *ctx, const void *data, size_t len)
+{
+    cmp_mem_access_t *mem = (cmp_mem_access_t*)ctx->buf;
+    if (mem->index + len <= mem->size) {
+        flash_write(&mem->buf[mem->index], data, len);
+        mem->index += len;
+        return len;
+    } else {
+        return 0;
+    }
+}
+
+void parameter_flash_storage_erase(void *dst)
+{
+    flash_unlock();
+    flash_sector_erase(dst);
+    flash_lock();
+}
+
+static void err_mark_false(void *arg, const char *id, const char *err)
+{
+    (void) id;
+    (void) err;
+
+    bool *b = (bool *)arg;
+    *b = false;
+}
+
+void parameter_flash_storage_save(void *dst, size_t dst_len, parameter_namespace_t *ns)
+{
+    cmp_ctx_t cmp;
+    cmp_mem_access_t mem;
+    uint32_t len;
+    bool success = true;
+
+    void *orig_dst = dst;
+
+    flash_unlock();
+
+    /* If there is no valid block, erase flash just to start from a pristine
+     * state. */
+    if (parameter_flash_storage_block_find_last_used(dst) == NULL) {
+        flash_sector_erase(dst);
+    }
+
+    /* Find first available flash block. */
+    dst = parameter_flash_storage_block_find_first_free(dst);
+
+    len = dst_len - (dst - orig_dst);
+
+    /* If the destination is too small to fit even the header, erase the block. */
+    if (len <= PARAMETER_FLASH_STORAGE_HEADER_SIZE) {
+        flash_sector_erase(orig_dst);
+        dst = orig_dst;
+        len = dst_len;
+    }
+
+    cmp_mem_access_init(&cmp,
+                        &mem,
+                        dst + PARAMETER_FLASH_STORAGE_HEADER_SIZE,
+                        len - PARAMETER_FLASH_STORAGE_HEADER_SIZE);
+
+    /* Replace the RAM writer with the special writer for flash. */
+    cmp.write = cmp_flash_writer;
+
+    /* Tries to write the config. If there is an error the callback will set
+     * success to false. */
+    parameter_msgpack_write_cmp(ns, &cmp, err_mark_false, &success);
+
+    if (success == false) {
+        flash_sector_erase(orig_dst);
+        flash_lock();
+        return parameter_flash_storage_save(orig_dst, dst_len, ns);
+    }
+
+    len = cmp_mem_access_get_pos(&mem);
+
+    parameter_flash_storage_write_block_header(dst, len);
+
+    flash_lock();
+}
+
+bool parameter_flash_storage_load(parameter_namespace_t *ns, void *src)
+{
+    int res;
+    uint32_t src_len;
+
+    src = parameter_flash_storage_block_find_last_used(src);
+
+    /* If no valid block was found signal an error. */
+    if (src == NULL) {
+        return false;
+    }
+
+    src_len = parameter_flash_storage_block_get_length(src);
+
+    bool successful = true;
+    res = parameter_msgpack_read(ns, src + PARAMETER_FLASH_STORAGE_HEADER_SIZE, src_len,
+                                 err_mark_false, &successful);
+
+    if (res != 0) {
+        return false;
+    }
+
+    return successful;
+}
+
+bool parameter_flash_storage_block_is_valid(void *p)
+{
+    uint8_t *block = (uint8_t *)p;
+    uint32_t crc, length;
+    size_t offset = 0;
+
+    /* Extract length checksum. */
+    memcpy(&crc, &block[offset], sizeof(crc));
+    offset += sizeof(crc);
+
+    /* Extract length. */
+    memcpy(&length, &block[offset], sizeof(length));
+    offset += sizeof(length);
+
+    /* Check that the length is valid. */
+    if (crc != crc32(CRC_INITIAL_VALUE, &length, sizeof(length))) {
+        return false;
+    }
+
+    /* Extract data checksum. */
+    memcpy(&crc, &block[offset], sizeof(crc));
+    offset += sizeof(crc);
+
+    /* Check that the data checksum is valid. */
+    if (crc != crc32(CRC_INITIAL_VALUE, &block[offset], length)) {
+        return false;
+    }
+
+    return true;
+}
+
+void parameter_flash_storage_write_block_header(void *dst, uint32_t len)
+{
+    uint32_t crc;
+    size_t offset = 0;
+
+    /* First write length checksum. */
+    crc = crc32(CRC_INITIAL_VALUE, &len, sizeof(uint32_t));
+    flash_write(dst + offset, &crc, sizeof(uint32_t));
+    offset += sizeof(uint32_t);
+
+    /* Then write the length itself. */
+    flash_write(dst + offset, &len, sizeof(uint32_t));
+    offset += sizeof(uint32_t);
+
+    /* Then write the data checksum. */
+    crc = crc32(CRC_INITIAL_VALUE, dst + PARAMETER_FLASH_STORAGE_HEADER_SIZE, len);
+    flash_write(dst + offset, &crc, sizeof(uint32_t));
+}
+
+uint32_t parameter_flash_storage_block_get_length(void *block)
+{
+    uint32_t *header = (uint32_t *) block;
+
+    return header[1];
+}
+
+void *parameter_flash_storage_block_find_last_used(void *p)
+{
+    uint8_t *block = (uint8_t *)p;
+    uint8_t *last = NULL;
+
+    while (parameter_flash_storage_block_is_valid(block)) {
+        last = block;
+        block += parameter_flash_storage_block_get_length(block);
+        block += PARAMETER_FLASH_STORAGE_HEADER_SIZE;
+    }
+
+    return last;
+}
+
+void *parameter_flash_storage_block_find_first_free(void *p)
+{
+    uint8_t *block = (uint8_t *)p;
+
+    while (parameter_flash_storage_block_is_valid(block)) {
+        block += parameter_flash_storage_block_get_length(block);
+        block += PARAMETER_FLASH_STORAGE_HEADER_SIZE;
+    }
+
+    return block;
+}

--- a/parameter_flash_storage.h
+++ b/parameter_flash_storage.h
@@ -1,0 +1,32 @@
+#ifndef PARAMETER_FLASH_STORAGE_H
+#define PARAMETER_FLASH_STORAGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <parameter/parameter.h>
+
+#define PARAMETER_FLASH_STORAGE_HEADER_SIZE (3 * sizeof(uint32_t))
+
+/** Erase config sector.
+ */
+void parameter_flash_storage_erase(void *dst);
+
+/** Writes the given parameter namespace to flash , prepending it with a CRC
+ * for integrity checks.
+ */
+void parameter_flash_storage_save(void *dst, size_t dst_len, parameter_namespace_t *ns);
+
+/** Loads the configuration from the flash
+ *
+ * @returns true if the operation was successful.
+ * @note If no valid block is found the parameter tree is unchanged.
+ */
+bool parameter_flash_storage_load(parameter_namespace_t *ns, void *src);
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/parameter_flash_storage_private.h
+++ b/parameter_flash_storage_private.h
@@ -1,0 +1,30 @@
+#ifndef PARAMETER_FLASH_STORAGE_PRIVATE_H
+#define PARAMETER_FLASH_STORAGE_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Returns true if the block at the given address has a valid checksum. */
+bool parameter_flash_storage_block_is_valid(void *block);
+
+/** Writes a header for the block at the address dst.
+ *
+ * @note The block first bytes (CONFIG_HEADER_SIZE) must be available to write
+ * the checksum to the block. */
+void parameter_flash_storage_write_block_header(void *dst, uint32_t len);
+
+/** Returns the length of the pointed block. */
+uint32_t parameter_flash_storage_block_get_length(void *block);
+
+/** Returns a pointer to the first free usable area of the block. */
+void *parameter_flash_storage_block_find_first_free(void *block);
+
+/** Returns a pointer to the last used block. */
+void *parameter_flash_storage_block_find_last_used(void *p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/flash_mock.cpp
+++ b/tests/flash_mock.cpp
@@ -1,0 +1,80 @@
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+#include "../flash.h"
+#include <cstring>
+
+extern "C" {
+
+void flash_lock(void)
+{
+    mock("flash").actualCall("lock");
+}
+
+void flash_unlock(void)
+{
+    mock("flash").actualCall("unlock");
+}
+
+void flash_sector_erase(void *p)
+{
+    mock("flash").actualCall("erase").withParameter("sector", p);
+
+    /* At least invalid any checksum in that block. */
+    memset(p, 0, 1);
+}
+
+void flash_write(void *addr, const void *data, size_t len)
+{
+    memcpy(addr, data, len);
+    mock("flash").actualCall("write");
+}
+
+uint8_t flash_addr_to_sector(void *addr)
+{
+    (void) addr;
+    return mock("flash").actualCall("addr_to_sector").returnIntValueOrDefault(0);
+}
+
+void flash_sector_erase_number(uint8_t number)
+{
+    mock("flash").actualCall("erase").withParameter("sector_number", number);
+}
+
+}
+
+
+TEST_GROUP(FlashMockTestCase)
+{
+
+};
+
+TEST(FlashMockTestCase, TestFlashLock)
+{
+    mock("flash").expectOneCall("lock");
+    flash_lock();
+}
+
+TEST(FlashMockTestCase, TestFlashUnlock)
+{
+    mock("flash").expectOneCall("unlock");
+    flash_unlock();
+}
+
+TEST(FlashMockTestCase, TestFlashErase)
+{
+    int a;
+    mock("flash").expectOneCall("erase").withParameter("sector", &a);
+    flash_sector_erase(&a);
+}
+
+TEST(FlashMockTestCase, TestFlashWrite)
+{
+    int a;
+    int b = 42;
+
+    mock("flash").expectOneCall("write");
+
+    flash_write(&a, &b, sizeof a);
+
+    CHECK_EQUAL(b, a);
+}

--- a/tests/parameter_flash_storage.cpp
+++ b/tests/parameter_flash_storage.cpp
@@ -1,0 +1,356 @@
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+#include "../parameter_flash_storage.h"
+#include "../parameter_flash_storage_private.h"
+#include <parameter/parameter_msgpack.h>
+#include <cstdio>
+#include <cstring>
+#include "crc/crc32.h"
+
+TEST_GROUP(ConfigSaveTestCase)
+{
+    uint8_t data[128];
+    parameter_namespace_t ns;
+
+    void setup()
+    {
+        mock("flash").ignoreOtherCalls();
+        parameter_namespace_declare(&ns, NULL, NULL);
+    }
+};
+
+TEST(ConfigSaveTestCase, SavingConfigErasesPages)
+{
+    // In case we cannot find a valid block we erase the sector, just in case
+    mock("flash").expectOneCall("erase").withParameter("sector", data);
+
+    parameter_flash_storage_save(data, sizeof(data), &ns);
+}
+
+TEST(ConfigSaveTestCase, SavingConfigLockUnlock)
+{
+    mock("flash").strictOrder();
+
+    mock("flash").expectOneCall("unlock");
+    mock("flash").expectOneCall("erase").withParameter("sector", data);
+    mock("flash").expectOneCall("write"); // data
+    mock("flash").expectOneCall("write"); // CRC(len)
+    mock("flash").expectOneCall("write"); // len
+    mock("flash").expectOneCall("write"); // crc(data)
+    mock("flash").expectOneCall("lock");
+
+    parameter_flash_storage_save(data, sizeof(data), &ns);
+
+    // We need to manually check expectations since we tuned the flash mock to preserve ordering.
+    mock("flash").checkExpectations();
+}
+
+static void err_cb(void *p, const char *id, const char *err)
+{
+    (void) p;
+    (void) id;
+    (void) err;
+    char msg[128];
+    snprintf(msg, sizeof msg, "MessagePack error on item \"%s\": \"%s\"", id, err);
+
+    FAIL(msg);
+}
+
+TEST(ConfigSaveTestCase, SavingConfigWorks)
+{
+    // Declare a parameter and gives it a value.
+    parameter_t p;
+    parameter_integer_declare(&p, &ns, "foo");
+    parameter_integer_set(&p, 10);
+
+    // Check that the flash writer is used
+    // Number of expected written bytes is implementation-dependent
+    // Change if if necessary
+    for (int i = 0; i < 8; i++) {
+        mock("flash").expectOneCall("write");
+    }
+
+    // Saves the parameter, then change its value
+    parameter_flash_storage_save(data, sizeof(data), &ns);
+    parameter_integer_set(&p, 20);
+    CHECK_EQUAL(20, parameter_integer_get(parameter_find(&ns, "/foo")));
+
+    // Loads the config back from saved state
+    // We add an offset to skip the CRC and the block length
+    parameter_msgpack_read(&ns,
+                           (char *)(&data[PARAMETER_FLASH_STORAGE_HEADER_SIZE]),
+                           sizeof(data) - PARAMETER_FLASH_STORAGE_HEADER_SIZE,
+                           err_cb, NULL);
+
+    // Check that the parameter has the same value as saved
+    CHECK_EQUAL(10, parameter_integer_get(parameter_find(&ns, "/foo")));
+}
+
+TEST_GROUP(ConfigLoadTestCase)
+{
+    uint8_t data[128];
+    parameter_namespace_t ns;
+    parameter_t foo;
+
+    void setup()
+    {
+        mock("flash").ignoreOtherCalls();
+        parameter_namespace_declare(&ns, NULL, NULL);
+        parameter_integer_declare(&foo, &ns, "foo");
+    }
+};
+
+TEST(ConfigLoadTestCase, SimpleLoad)
+{
+    // Set a value, then save it
+    parameter_integer_set(&foo, 20);
+    parameter_flash_storage_save(data, sizeof(data), &ns);
+
+    // Change the value
+    parameter_integer_set(&foo, 10);
+
+    // Load the tree
+    auto res = parameter_flash_storage_load(&ns, data);
+
+    // Value should be back to what it was
+    CHECK_TRUE(res);
+    CHECK_EQUAL(20, parameter_integer_get(&foo));
+}
+
+TEST(ConfigLoadTestCase, CRCIsChecked)
+{
+    // Set a value, then save it
+    parameter_integer_set(&foo, 20);
+    parameter_flash_storage_save(data, sizeof(data), &ns);
+
+    // Change the value
+    parameter_integer_set(&foo, 10);
+
+    // Corrupt data
+    data[0] ^= 0x40;
+
+    // Load the tree
+    auto res = parameter_flash_storage_load(&ns, data);
+
+    // Value should not have changed
+    CHECK_FALSE(res);
+    CHECK_EQUAL(10, parameter_integer_get(&foo));
+}
+
+TEST(ConfigLoadTestCase, InvalidConfigReturnsFalse)
+{
+    // This test checks that loading an invalid config fails, even if the
+    // checksum is correct.
+    // This might be the case if the layout of the parameter tree changes for
+    // example.
+    parameter_integer_set(&foo, 20);
+    parameter_flash_storage_save(data, sizeof(data), &ns);
+
+    // Create a new different tree
+    parameter_namespace_declare(&ns, NULL, NULL);
+    parameter_integer_declare(&foo, &ns, "bar");
+
+    // Try to load it
+    auto res = parameter_flash_storage_load(&ns, data);
+
+    // Verify that the load was not succesful
+    CHECK_FALSE(res);
+}
+
+TEST_GROUP(BlockValidityTestGroup)
+{
+    uint8_t block[256 + PARAMETER_FLASH_STORAGE_HEADER_SIZE];
+
+    void setup()
+    {
+        memset(block, 0, sizeof(block));
+
+        mock("flash").disable();
+        parameter_flash_storage_write_block_header(block,
+                                                   sizeof(block) -
+                                                   PARAMETER_FLASH_STORAGE_HEADER_SIZE);
+        mock("flash").enable();
+    }
+
+};
+
+TEST(BlockValidityTestGroup, DefaultBlockIsValid)
+{
+    CHECK_TRUE(parameter_flash_storage_block_is_valid(block));
+}
+
+TEST(BlockValidityTestGroup, InvalidLengthChecksumMakesItInvalid)
+{
+    block[0] ^= 0xaa;
+    CHECK_FALSE(parameter_flash_storage_block_is_valid(block));
+}
+
+TEST(BlockValidityTestGroup, InvalidLengthIsInvalid)
+{
+    block[5] ^= 0xaa;
+    CHECK_FALSE(parameter_flash_storage_block_is_valid(block));
+}
+
+TEST(BlockValidityTestGroup, InvalidDataCheckSumIsInvalid)
+{
+    block[127] ^= 0xaa;
+    CHECK_FALSE(parameter_flash_storage_block_is_valid(block));
+}
+
+TEST(BlockValidityTestGroup, FreshFlashIsInvalid)
+{
+    /* Checks that a fresh flash page (all 0xff) is invalid. */
+    memset(block, 0xff, sizeof(block));
+    CHECK_FALSE(parameter_flash_storage_block_is_valid(block));
+}
+
+TEST_GROUP(BlockGetLengthTestCase)
+{
+    uint8_t block[10 + PARAMETER_FLASH_STORAGE_HEADER_SIZE];
+};
+
+TEST(BlockGetLengthTestCase, CanGetBlockLength)
+{
+    mock("flash").disable();
+    parameter_flash_storage_write_block_header(block, 10);
+    mock("flash").enable();
+
+    auto res = parameter_flash_storage_block_get_length(block);
+
+    CHECK_EQUAL(10, res);
+}
+
+TEST_GROUP(FindFirstValidBlockTestGroup)
+{
+    uint8_t block[256];
+};
+
+TEST(FindFirstValidBlockTestGroup, ReturnsFirstPartofTheBlock)
+{
+    auto first_block = parameter_flash_storage_block_find_first_free(block);
+    POINTERS_EQUAL(&block[0], first_block);
+}
+
+TEST(FindFirstValidBlockTestGroup, SkipsAlreadyUsedBlocks)
+{
+    mock("flash").disable();
+    parameter_flash_storage_write_block_header(block, 10);
+    auto first_block = parameter_flash_storage_block_find_first_free(block);
+
+    POINTERS_EQUAL(&block[10 + PARAMETER_FLASH_STORAGE_HEADER_SIZE], first_block);
+}
+
+TEST(FindFirstValidBlockTestGroup, FindNoUsedBlockReturnsNULL)
+{
+    auto last_block = parameter_flash_storage_block_find_last_used(block);
+    POINTERS_EQUAL(NULL, last_block);
+}
+
+TEST(FindFirstValidBlockTestGroup, FindLastUsedBlock)
+{
+    mock("flash").disable();
+    parameter_flash_storage_write_block_header(block, 10);
+
+    POINTERS_EQUAL(block, parameter_flash_storage_block_find_last_used(block));
+}
+
+TEST_GROUP(ConfigLoadBalancingTestGroup)
+{
+    parameter_namespace_t ns;
+    uint8_t block[256];
+
+    void setup()
+    {
+        mock("flash").ignoreOtherCalls();
+        parameter_namespace_declare(&ns, NULL, NULL);
+    }
+
+};
+
+TEST(ConfigLoadBalancingTestGroup, ConfigSavingIsLoadBalanced)
+{
+    // Checks that saving a config declares a new block at the end of the flash
+    // config page.
+
+    // First, declare a parameter
+    parameter_t p;
+    parameter_integer_declare(&p, &ns, "foo");
+    parameter_integer_set(&p, 10);
+
+    // Checks that the first save is done on the first block
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+    POINTERS_EQUAL(block, parameter_flash_storage_block_find_last_used(block));
+
+    // Checks that the second save is on the second block
+    auto second_block = parameter_flash_storage_block_find_first_free(block);
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+    POINTERS_EQUAL(second_block, parameter_flash_storage_block_find_last_used(block));
+}
+
+TEST(ConfigLoadBalancingTestGroup, CanLoadCorrectBlock)
+{
+    // Checks that config page loading chooses the latest version correctly
+
+    // First, declare a parameter
+    parameter_t p;
+    parameter_integer_declare(&p, &ns, "foo");
+
+    // Give it a value then save
+    parameter_integer_set(&p, 1);
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+
+    // Give it a value again then save
+    parameter_integer_set(&p, 2);
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+
+    // Finally load it from flash and see if latest version was used
+    parameter_integer_set(&p, 3);
+
+    auto res = parameter_flash_storage_load(&ns, block);
+    CHECK_TRUE(res);
+    CHECK_EQUAL(2, parameter_integer_get(&p));
+}
+
+TEST(ConfigLoadBalancingTestGroup, CanErasePageIfNotenoughSpaceLeft)
+{
+    // Checks that we erase the whole block if we don't have enough space left
+    // to write the config header
+
+    uint8_t block[30];
+
+    parameter_t p;
+    parameter_integer_declare(&p, &ns, "foo");
+
+    // Give it a value then save
+    parameter_integer_set(&p, 1);
+
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+
+    // We used 10 + PARAMETER_FLASH_STORAGE_HEADER_SIZE bytes, so there is not enough free space
+    // available for the header
+    CHECK_EQUAL(10, parameter_flash_storage_block_get_length(block));
+
+    mock("flash").expectOneCall("erase").withParameter("sector", block);
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+}
+
+TEST(ConfigSaveTestCase, CanErasePageIfNotenoughSpaceLeftForData)
+{
+    uint8_t block[36];
+
+    parameter_t p;
+    parameter_integer_declare(&p, &ns, "foo");
+
+    // Give it a value then save
+    parameter_integer_set(&p, 1);
+
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+
+    // We used 10 + PARAMETER_FLASH_STORAGE_HEADER_SIZE bytes, so there is not enough free space
+    // available
+    CHECK_EQUAL(10, parameter_flash_storage_block_get_length(block));
+
+    mock("flash").expectOneCall("erase").withParameter("sector", block);
+    mock("flash").expectOneCall("erase").withParameter("sector", block);
+    parameter_flash_storage_save(block, sizeof(block), &ns);
+}

--- a/tests/parameter_flash_storage.cpp
+++ b/tests/parameter_flash_storage.cpp
@@ -65,10 +65,8 @@ TEST(ConfigSaveTestCase, SavingConfigWorks)
 
     // Check that the flash writer is used
     // Number of expected written bytes is implementation-dependent
-    // Change if if necessary
-    for (int i = 0; i < 8; i++) {
-        mock("flash").expectOneCall("write");
-    }
+    // Change it if necessary
+    mock("flash").expectNCalls(8, "write");
 
     // Saves the parameter, then change its value
     parameter_flash_storage_save(data, sizeof(data), &ns);
@@ -137,12 +135,8 @@ TEST(ConfigLoadTestCase, CRCIsChecked)
     CHECK_EQUAL(10, parameter_integer_get(&foo));
 }
 
-TEST(ConfigLoadTestCase, InvalidConfigReturnsFalse)
+TEST(ConfigLoadTestCase, FailsIfParameterTreeLayoutDoesNotMatchSavedStructure)
 {
-    // This test checks that loading an invalid config fails, even if the
-    // checksum is correct.
-    // This might be the case if the layout of the parameter tree changes for
-    // example.
     parameter_integer_set(&foo, 20);
     parameter_flash_storage_save(data, sizeof(data), &ns);
 


### PR DESCRIPTION
So most of the code was extracted from another implementation (epuck2), but still would like to have a second set of eyes on it.

I split it out for use with the beacons initially, but I think it can also be used for the motor board config we have talked about.

edit: It currently depends on the `refactor-platform-specific-code` branch for `parameter`, which I am waiting for merge. Otherwise the parameter tests are not building.