### PR TITLE
Fix unaligned pointer access

### DIFF
--- a/parameter_flash_storage.c
+++ b/parameter_flash_storage.c
@@ -180,7 +180,8 @@ void parameter_flash_storage_write_block_header(void *dst, uint32_t len)
 
 uint32_t parameter_flash_storage_block_get_length(void *block)
 {
-    uint32_t *header = (uint32_t *) block;
+    uint32_t header[2];
+    memcpy(header, block, sizeof header);
 
     return header[1];
 }


### PR DESCRIPTION
This commit removes a (possible) unaligned pointer, which could return weird reads. It was found using clang's undefined behaviour sanitizer (UBSan) on a unit test build.

It might be related to #3 ("Can't config_save for a second time on UWBboards"), if the size was right. This should be tested.